### PR TITLE
[#5] 유송연

### DIFF
--- a/Baekjoon/Gold/7662_이중_우선순위_큐/songyeon.java
+++ b/Baekjoon/Gold/7662_이중_우선순위_큐/songyeon.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int T = Integer.parseInt(br.readLine());
+
+        for(int t=0;t<T;t++){
+            int k = Integer.parseInt(br.readLine());
+            TreeMap<Integer, Integer> pq = new TreeMap<>(); // 우선순위 큐(맵으로 구현)
+
+            for (int i = 0; i < k; i++) {
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                Character cmd = st.nextToken().charAt(0); // 명령어
+                int value = Integer.parseInt(st.nextToken()); // 값
+
+                switch(cmd){
+                    case 'I':
+                        if (pq.containsKey(value)){
+                            pq.put(value, pq.get(value) + 1);
+                        }
+                        else {
+                            pq.put(value, 1);
+                        }
+                        break;
+
+                    case 'D':
+                        if (!pq.isEmpty()){
+                            int target; // 지워질 값
+
+                            if (value == -1) { 
+                                target = pq.firstKey(); // 가장 작은 수
+                            }
+                            else { 
+                                target = pq.lastKey(); // 가장 큰 수
+                            }
+
+                            if (pq.get(target) == 1){ // 중복 값이 없을 때 맵에서 삭제
+                                pq.remove(target);
+                            }
+                            else {
+                                pq.put(target, pq.get(target) - 1);
+                            }
+                        }
+                        break;
+                }
+            }
+            if (!pq.isEmpty()){
+                bw.write(pq.lastKey()+" "+pq.firstKey()+"\n");
+            }
+            else {
+                bw.write("EMPTY\n");
+            }
+        }
+
+        bw.flush(); // 결과 출력
+        br.close();
+        bw.close();
+    }
+}


### PR DESCRIPTION
#5 7665 - 이중 우선순위 큐

### Review

- 처음에 각각 최대 힙과 최소 힙으로 구현된 우선순위 큐 2개를 사용했다가 시간 초과가 났다. 

- T값의 범위가 주어지지 않았다는 것을 간과했던 것 같다. 

- 이후에는 블로그 도움 받아서 TreeMap으로 풀었다. TreeMap은 값을 넣을 경우 자동으로 키값에 대해 오름차 정렬된다.


### 풀이과정
1. TreeMap으로 우선순위 큐를 구현한다.
2. 'I' 명령이 들어온 경우, TreeMap에 값을 넣는다. 
3. 'D' 명령이 들어온 경우, TreeMap이 비어있지 않은 경우에 대해서만 다음과 같이 연산한다. 
- 1 이 들어왔을 때, `target = pq.lastKey()`  : 가장 큰 값을 지워질 대상으로 설정한다.
-  -1 이 들어왔을 때 `target = pq.firstKey()` : 가장 작은 값을 지워질 대상으로 설정한다.
4. 지워질 대상의 개수 체크를 진행한다. 만약, 하나라면 **TreeMap에서 삭제하고, 아닐 경우  TreeMap의 값만 -1 한다.**
5. TreeMap이 비었는지 확인하고, 그에 따른 결과를 출력한다.

