### PR TITLE
[#22] 김은서

### DIFF
--- a/Baekjoon/Gold/3584_가장_가까운_공통_조상/EunSeo.java
+++ b/Baekjoon/Gold/3584_가장_가까운_공통_조상/EunSeo.java
@@ -31,11 +31,11 @@ public class Main {
 
     }
     static void findParentNode(int node1, int node2){
-        while(node1 > 0){ // node1 < 0 인 경우 루트 노드에 도달한 것
+        while(node1 > 0){ // node1 > 0 인 경우 루트 노드에 도달한 것
             visit[node1] = true;
             node1 = parentNode[node1]; // node1 의 부모를 다시 node1에 저장하여 while 반복
         }
-        while(node2 > 0){ // node2 < 0 인 경우 루트 노드에 도달한 것
+        while(node2 > 0){ // node2 > 0 인 경우 루트 노드에 도달한 것
             if(visit[node2]){ // 만약 visit[node2] 가 이미 방문 했던 노드일 경우
                 // 해당 노드는 node1의 부모 노드고 node1과 node2의 최소 공통 부모 노드다.
                 System.out.println(node2);

--- a/Baekjoon/Gold/3584_가장_가까운_공통_조상/EunSeo.java
+++ b/Baekjoon/Gold/3584_가장_가까운_공통_조상/EunSeo.java
@@ -33,7 +33,7 @@ public class Main {
     static void findParentNode(int node1, int node2){
         while(node1 > 0){ // node1 < 0 인 경우 루트 노드에 도달한 것
             visit[node1] = true;
-            node1 = parentNode[node1]; // node1 의 부모 -> nextNode
+            node1 = parentNode[node1]; // node1 의 부모를 다시 node1에 저장하여 while 반복
         }
         while(node2 > 0){ // node2 < 0 인 경우 루트 노드에 도달한 것
             if(visit[node2]){ // 만약 visit[node2] 가 이미 방문 했던 노드일 경우

--- a/Baekjoon/Gold/3584_가장_가까운_공통_조상/EunSeo.java
+++ b/Baekjoon/Gold/3584_가장_가까운_공통_조상/EunSeo.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int n;
+    static boolean[] visit;
+    static int[] parentNode;
+    static StringTokenizer st;
+    public static void main(String[] args) throws Exception{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine()); // 테스트 케이스 개수
+
+        for(int t = 0; t<T; t++){
+            n = Integer.parseInt(br.readLine()); // 노드의 수
+            visit = new boolean[n+1]; // 방문 처리를 위한 배열 visit
+            parentNode = new int[n+1];
+
+            for(int i = 1; i<n; i++){ // 연결 정보 입력
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                parentNode[b] = a; // 배열 인덱스 = 배열 값 노드의 자식 노드
+            }
+
+            st = new StringTokenizer(br.readLine());
+            int find1 = Integer.parseInt(st.nextToken()); // 공통 부모를 찾을 노드들
+            int find2 = Integer.parseInt(st.nextToken());
+            findParentNode(find1, find2);
+        }
+
+    }
+    static void findParentNode(int node1, int node2){
+        while(node1 > 0){ // node1 < 0 인 경우 루트 노드에 도달한 것
+            visit[node1] = true;
+            node1 = parentNode[node1]; // node1 의 부모 -> nextNode
+        }
+        while(node2 > 0){ // node2 < 0 인 경우 루트 노드에 도달한 것
+            if(visit[node2]){ // 만약 visit[node2] 가 이미 방문 했던 노드일 경우
+                // 해당 노드는 node1의 부모 노드고 node1과 node2의 최소 공통 부모 노드다.
+                System.out.println(node2);
+                break;
+            }else{
+                node2 = parentNode[node2];
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
#22 가장 가까운 공통 조상

### 풀이방법

- 예제 입력에서 a는 b의 조상이다는 것을 이용하여 parentNode[b] = a 로 저장하여 배열 인덱스 = 해당 배열 인덱스 값의 자식형태로 노드 연결 정보를 저장한다.
- 가장 가까운 공통 조상 노드를 구하는 노드중 하나로부터 루트노드까지 visit를 한 뒤, 다른 노드 역시 루트노드까지 visit을 한다.
- 이때 2번째로 부모를 찾는 노드가 루트노드까지 visit을 하는 중, 이미 첫번째 노드에서 방문하여 visit처리를 한 노드를 만나면 그 노드가 두 노드의 가장 가까운 공통 조상이다.

### 어려웠던점

LCA 알고리즘을 몰라서 해설의 힘을 빌렸다..
다만 해당 풀이는 가장 가까운 공통 조상을 구하는 노드가 한쌍만 존재했기에 가능한 풀이법이었다. 
만약 가까운 공통 조상을 구하는 노드가 3가지 이상이었다면 위 풀이법으로는 풀기 어려웠을 것이다.
같은 유형의 문제가 나오면 LCA를 이용하여 풀 수 있도록 LCA알고리즘을 공부해야겠음을 느꼈다..