### PR TITLE
[#39] 김유진

### DIFF
--- a/Baekjoon/Gold/17073_나무_위의_빗물/k_yujin.java
+++ b/Baekjoon/Gold/17073_나무_위의_빗물/k_yujin.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Main {
+
+
+    public static void main(String[] args) throws IOException {
+
+        int count = 0;
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int nodeCount = Integer.parseInt(st.nextToken());
+        int rainCount = Integer.parseInt(st.nextToken());
+
+        ArrayList [] edge = new ArrayList[nodeCount+1];
+
+        // 초기화
+        for(int i=1; i<=nodeCount; i++){
+            edge[i] = new ArrayList<Integer>();
+        }
+
+        // 간선 추가
+        for(int i=0; i<nodeCount-1; i++){
+            st = new StringTokenizer(br.readLine());
+            int v = Integer.parseInt(st.nextToken());
+            int u = Integer.parseInt(st.nextToken());
+
+            edge[v].add(u);
+            edge[u].add(v);
+
+        }
+
+
+        // 말단 노드 구하기
+        for(int i = 2; i< edge.length; i++) {
+            if (edge[i].size() == 1)
+                count++;
+        }
+
+        // 출력과 같이 소수점 10자리로 포맷팅
+        System.out.println(String.format("%.10f", (double)rainCount/count));
+
+    }
+
+
+
+}
+
+
+
+


### PR DESCRIPTION
[#39] 백준 17073 - 나무 위의 빗물

### 접근 방법
**방법 1 : 말단 노드의 Pi를 각각 구해 더하기**
빗물이 고여 있을 수 있는 노드는 가장 말단 노드 뿐이므로 말단 노드를 이용한다. 그리고 i 번째 말단 노드까지 가는 확률을 
구하고 빗물 양을 곱해 Pi를 구한다. 그 후 모든 Pi를 더한 후 마지막에 말단 노드 수로 나눈다.

**i 번째 말단 노드까지 가는 확률**

-  1/(루트 자식 수)* 1/(두 번째 깊이 노드 수) ... 1*(i-1 번째 깊이 노드 수)

**구현 방법**
1. DFS 탐색을 재귀함수로 구현하여 재귀 호출 시 확률을 곱해주어 각 말단 노드까지 가는 확률을 알아낸다.
2. (w)*(i번째 말단 노드로 오는 확률) 을 구해 결과 값에 더한다.
3. 결과값을 말단 노드 수로 나눈 후 출력한다.

시간 초과로 실패

**방법 2 : 말단 노드 수가 곧 Pi의 평균이다.**
방법 1은 각 Pi를 모두 구하고 더한 다음 말단 노드 수로 나눴다. 
하지만 전체 Pi를 구하는 수식을 생각하면 말단 노드로 가는 확률을 구할 필요가 없었다.

i번째 말단 노드로 가는 확률을 Ki라고 할 때, pi = (w)*(Ki)이다. 
문제에서 구해야 하는 것은 ∑Pi인데 ∑Pi = W * ∑Ki 이고 ∑Ki는 1이다.  빗물은 언제나 말단에 도달하기 때문이다.
그러므로 ∑Pi의 평균은 W/(말단 노드의 수)가 된다.

**구현 방법**
1. n과 w를 입력 받는다.
2. 간선 정보를 ArrayList에 저장한다.
3. 간선 배열을 탐색하면서 연결된 노드가 1개인 노드를 구하면 count++ 한다. (말단노드)
4. (double)w/ count를 출력한다. 이떄 출력 결과에 따라 소수자리는 10자로 나타낸다.

