### PR TITLE
[#64] 김은서

### DIFF
--- a/Baekjoon/Silver/11055_가장_큰_증가하는_부분_수열/EunSeo.java
+++ b/Baekjoon/Silver/11055_가장_큰_증가하는_부분_수열/EunSeo.java
@@ -1,0 +1,33 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static int[] num;
+    public static Integer[] sum;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine()); // 수열 길이
+        num = new int[n];
+        sum = new Integer[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0; i<n; i++){
+            num[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for(int i = 0; i<n; i++){
+            sum[i] = num[i];
+            for(int j = 0; j<i; j++){
+                if(num[i] > num[j]) {
+                    sum[i] = Math.max(sum[j]+num[i], sum[i]);
+                }
+            }
+        }
+
+        Arrays.sort(sum, Collections.reverseOrder());
+        System.out.println(sum[0]);
+    }
+}


### PR DESCRIPTION
#64 11055 - 가장 큰 증가하는 부분 수열

## 풀이 방법

- 각 수는 수열의 합에서 자기 자신을 더한 수열을 이루기 때문에 sum에 자기 자신을 삽입한다.
- 인덱스 i번째 수를 기준으로 0부터 i번째까지 반복하여 num[i]와 num[j]의 크기를 비교한다.
- num[i]가 더 크다면 sum[j] + num[i] 와 sum[i] 중 큰 값을 구해서 현재 수의 수열 합 sum[i]에 저장한다.
> 만약 num[j]가 num[i]보다 작아서 조건을 만족해도 중간에 감소한 수 라면, num[j] 까지의 수열 합 sum[j]는 
이미 최대 합이 아니게 되고, 이때 sum[j]에 num[i]를 더해도 sum[i]보다 작게 되므로 max메소드를 사용해서 최대 수열 합을 기억하기 위함이다.

![image](https://github.com/Algo-Masters/algo-practice/assets/89981466/f0407566-75fd-442c-969f-ff4f7abeefe2)



- 수열 합 sum 에서 최대 수열 합을 찾기 위해 sum 배열을 내림차순 정렬하고 첫번째 원소를 출력했다.