### PR TITLE
[#79] 김은서

### DIFF
--- a/Baekjoon/Silver/15724_주지수/EunSeo.java
+++ b/Baekjoon/Silver/15724_주지수/EunSeo.java
@@ -1,0 +1,33 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+    public static int[][] population;
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        population = new int[n+1][m+1];
+        for(int i = 1; i<=n; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 1; j<=m; j++){
+                int pop = Integer.parseInt(st.nextToken());
+                population[i][j] = pop + population[i-1][j] + population[i][j-1] - population[i-1][j-1];
+            }
+        }
+        int k = Integer.parseInt(br.readLine());
+        for(int i = 0; i<k; i++){
+            st = new StringTokenizer(br.readLine());
+            int x1 = Integer.parseInt(st.nextToken());
+            int y1 = Integer.parseInt(st.nextToken());
+            int x2 = Integer.parseInt(st.nextToken());
+            int y2 = Integer.parseInt(st.nextToken());
+
+            int result = population[x2][y2] - population[x2][y1-1] - population[x1-1][y2] + population[x1-1][y1-1];
+            System.out.println(result);
+        }
+    }
+}


### PR DESCRIPTION
#79 15724 - 주지수

## 풀이 방법
- 처음에는 단순히 범위 내 숫자들을 더해서 구하려고 했으나 구하는 과정에서 여러번 for문을 중첩시켜야해서 시간초과가 날 것이라 생각했다.
- 따라서 인구 수를 입력 받음과 동시에 이전 인구 수와 현재 인구 수를 더해줘 구간 합을 구해 연산 횟수를 줄이고자 했다.
- 구간 합을 구할 때 pop[i][j] + pop[i-1][j] + pop[i][j-1] 을 해주고 pop[i-1][j-1]이 중복되어 더해지기 때문에 한번 빼줘야한다.
- 범위 내 인구 수를 출력할 때 pop[i][j] - pop[i-1][j] - pop[i][j-1] 을 해주고 pop[i-1][j-1]이 중복되어 빼지기 때문에 한번 더해줘야한다. 