### PR TITLE
[#95] 김은서

### DIFF
--- a/Baekjoon/Gold/22862_가장_긴_짝수_연속한_부분_수열/Eunseo.java
+++ b/Baekjoon/Gold/22862_가장_긴_짝수_연속한_부분_수열/Eunseo.java
@@ -1,0 +1,48 @@
+package ex3003;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+	static int[] arr;
+	public static void main(String[] args) throws Exception  {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		arr = new int[n];
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i<n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		int start = 0;
+		int end = 0;
+		int oddNum = 0;
+		int maxLength = -1;
+		
+		while(end < arr.length) {
+			if(oddNum < k) {
+				if(arr[end] % 2 == 1) {
+					oddNum += 1;
+				}
+				end++;
+				maxLength = Math.max(maxLength, end-start-oddNum);
+			}
+			else if(arr[end] % 2 == 0) {
+				end++;
+				maxLength = Math.max(maxLength, end-start-oddNum);
+			}
+			else if(oddNum == k && arr[end] % 2 == 1) {
+				if(arr[start] % 2 == 1) {
+					oddNum -= 1;
+				}
+				start++;
+			}
+		}
+		System.out.println(maxLength);
+	}
+}


### PR DESCRIPTION
#95 백준 - 22862

## 초기 접근
kcount = 홀수 개수, count = 수열 길이
- 슬라이딩 도어 기법을 사용해서 kcount가 k값보다 작거나 같을 동안 반복하여 end가 가리키는 곳이 홀수면 kcount를 증가 시키고 end++, 짝수면 count를 증가 시킨다.
- kcount가 k값보다 커진 경우 지금까지 누적한 수열길이 count를 결과 값 변수 result와 Math.max 대소 비교를 통해 큰 값으로 result를 갱신한다.
- start포인터를 1 증가 시킨다.
- end를 start포인터가 있는 인덱스로 옮긴다.
- 이를 end가 수열 길이를 넘지 않는 동안 반복한다
-> 시간 초과...

## 다른 접근
oddNum = 홀수 개수
- 마찬가지로 end가 수열을 넘지 않는 동안 반복하여
- oddNum이 k값 보다 작은 경우, 현재 end포인터가 가리키는 수가 홀수라면 oddNum을 1 증가 시킨다.
- 그리고 end포인터를 1 증가 시키고 수열 최대 길이 저장 변수 maxLength와 대소 비교를 하여 수열 최대 길이를 갱신한다.
- 이때 수열의 길이는 start부터 end 까지 수의 개수에서 홀수 개수인 oddNum을 뺀 것이다.
- 만약 end포인터가 가리키는 수가 짝수라면
- end 포인터를 1 증가 시키고 maxLength와 대소 비교를 한다. 
- 만약 oddNum이 k값과 같고 현재 end가 가리키는 곳이 홀수라면
- 현재 start가 가리키는 곳이 홀수인지 판단한 후 홀수라면 oddNum을 1 감소 시키고 start를 1 증가시킨다.
- start가 가리키는 곳이 짝수면 start를 1 증가 시키기만 한다.

## 시간 초과의 원인
- 정답도 마찬가지로 슬라이딩 도어 기법을 사용했지만 
- 내 코드와의 차이점을 보니 나는 다시 end를 start와 같은 인덱스로 초기화하여 start부터 탐색했다면
- 정답 코드는 최초 oddNum이 k와 같은 값이 되는 end포인트에서 부터 계속 진행하며
- 최대 수열 길이를 갱신해 나갔다는 차이점이 원인인 것 같다.