### PR TITLE
[#64] 유송연

### DIFF
--- a/Baekjoon/Silver/11055_가장_큰_증가하는_부분_수열/songyeon.java
+++ b/Baekjoon/Silver/11055_가장_큰_증가하는_부분_수열/songyeon.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());
+        int numbers[] = new int[N + 1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for (int i = 1; i <= N; i++) {
+            numbers[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] dp = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            dp[i] = numbers[i];
+            for (int j = 1; j < i; j++) {
+                if (numbers[i] > numbers[j] && dp[i] < dp[j] + numbers[i]) {
+                    dp[i] = dp[j] + numbers[i];
+                }
+            }
+        }
+
+        int max = Integer.MIN_VALUE;
+        for (int i = 1; i <= N; i++) {
+            if (dp[i] > max) {
+                max = dp[i];
+            }
+        }
+
+        bw.write(max + "\n");
+        bw.flush();
+
+        br.close();
+        bw.close();
+
+    }
+}


### PR DESCRIPTION
#64 백준11055 - 가장 큰 증가하는 부분 수열

### Review
- dp 배열에 각 numbers[i] 를 포함했을 때의 가능한 수열의 합을 저장한다.
- 가장 긴 증가하는 부분 수열 문제와 거의 동일하게 풀었다.

### 풀이과정
1. 숫자들을 numbers 배열에 담는다.
2. dp[i] 값은 numbers[i]로 초기화한다.
3.  `numbers[i] > numbers[j]` 일때, `dp[i] < dp[j] + numbers[i]` 라면 `dp[i]  = dp[j] + numbers[i]`
4. dp 배열들 중, 가장 큰 값을 찾아 출력한다.

